### PR TITLE
Add TwoFactorException handling

### DIFF
--- a/gitsuggest/commandline.py
+++ b/gitsuggest/commandline.py
@@ -31,6 +31,7 @@ import webbrowser
 
 import crayons
 import github
+from github.GithubException import BadCredentialsException, TwoFactorException
 
 from .suggest import GitSuggest
 from .utilities import ReposToHTML
@@ -79,10 +80,19 @@ def main():
                         password=password,
                         token=None,
                         deep_dive=arguments.deep_dive)
-    except github.BadCredentialsException:
+    except BadCredentialsException:
         print('')
         print(crayons.red(
             'Incorrect password provided, to skip password enter nothing.',
+            bold=True))
+        exit()
+    except TwoFactorException:
+        print('')
+        print(crayons.red(
+            '\n'.join([
+                'You have 2FA set up, please enter a personal access token.',
+                'You can generate one on https://github.com/settings/tokens'
+            ]),
             bold=True))
         exit()
 


### PR DESCRIPTION
This handles the exception raised when logging in with the password while 2FA is enabled for the GitHub account.
The printed looks similar to the `BadCredentialsException` message.

Since using `github.TwoFactorException` resulted in `AttributeError: module 'github' has no attribute 'TwoFactorException'` (which for some reason works for other exceptions), I used the `from x import y` syntax and imported `BadCredentialsException` in the same way to keep it consistent.

I think this fixes #4 when merged, since people trying to log in with 2FA enabled are directed towards GitHub tokens.